### PR TITLE
Name availability check

### DIFF
--- a/Web/api/draft.py
+++ b/Web/api/draft.py
@@ -1,11 +1,11 @@
 import json
 import logging
+import re
 
-import MySQLdb
-
-from config import DBConfig
+from config import DBConfig, DraftConfig
 from utils.base_handler import BaseHandler
 from utils.db import latest_season_db, jsonify_query_results
+from utils.wrappers import require_params, db_conn, db_cursor
 
 
 class DraftHandler(BaseHandler):
@@ -14,42 +14,30 @@ class DraftHandler(BaseHandler):
 
 
 class DraftNameHandler(BaseHandler):
-    def get(self):
-        try:
-            db = MySQLdb.connect(
-                host=DBConfig.HOST,
-                user=DBConfig.USER,
-                passwd=DBConfig.PASSWORD,
-                db=latest_season_db()
-            )
-            names = map(lambda x: x['name'], jsonify_query_results(db, 'SELECT name FROM drafts'))
-            return json.dumps({'names': names})
-        except:
-            logging.exception('Unable to fetch draft names')
-            self.abort(500)
+    @require_params('name')
+    @db_cursor(latest_season_db())
+    def post(cursor, name, self):
+        if re.match('^[0-9a-zA-Z \-_]+$', name) is None or len(name) > DraftConfig.MAX_TEAM_NAME_LENGTH:
+            return self.make_response('Invalid name', status=415)
+
+        cursor.execute('SELECT name FROM drafts WHERE name=%s', (name, ))
+        for result in cursor:
+            return self.make_response('Name exists')
+
+        return self.make_response('No draft exists with that name', status=404)
 
 
 class DraftTeamHandler(BaseHandler):
-    def get(self):
-        try:
-            db = MySQLdb.connect(
-                host=DBConfig.HOST,
-                user=DBConfig.USER,
-                passwd=DBConfig.PASSWORD,
-                db=latest_season_db()
-            )
-
-            player_query = ('SELECT id, playerName, playerPositionCode, t.teamAbbrev, t.teamFullName '
-                            'FROM players JOIN (SELECT teamFullName, teamAbbrev FROM teams) as t '
-                            'ON playerTeamsPlayedFor = t.teamAbbrev')
-            goalie_query = ('SELECT id, (SELECT CONCAT(teamFullName, \' Goaltenders\')) AS playerName, '
-                            '(SELECT \'G\') as playerPositionCode, teamAbbrev, teamFullName FROM teams')
-            players = jsonify_query_results(db, player_query)
-            goalies = jsonify_query_results(db, goalie_query)
-            return json.dumps(players + goalies)
-        except:
-            logging.exception('Unable to fetch data from DB')
-            self.abort(500)
+    @db_conn(latest_season_db())
+    def get(db, self):
+        player_query = ('SELECT id, playerName, playerPositionCode, t.teamAbbrev, t.teamFullName '
+                        'FROM players JOIN (SELECT teamFullName, teamAbbrev FROM teams) as t '
+                        'ON playerTeamsPlayedFor = t.teamAbbrev')
+        goalie_query = ('SELECT id, (SELECT CONCAT(teamFullName, \' Goaltenders\')) AS playerName, '
+                        '(SELECT \'G\') as playerPositionCode, teamAbbrev, teamFullName FROM teams')
+        players = jsonify_query_results(db, player_query)
+        goalies = jsonify_query_results(db, goalie_query)
+        return json.dumps(players + goalies)
 
 
 class DraftSubmitHandler(BaseHandler):
@@ -60,12 +48,12 @@ class DraftSubmitHandler(BaseHandler):
         except:
             logging.warning('Submit data was malformed')
             self.abort(400)
-        return 'OK'
+        return self.make_response('OK')
 
 
 routes = [
     ('/draft', DraftHandler),
-    ('/draft/names', DraftNameHandler),
+    ('/draft/name', DraftNameHandler),
     ('/draft/players', DraftTeamHandler),
     ('/draft/submit', DraftSubmitHandler)
 ]

--- a/Web/api/draft.py
+++ b/Web/api/draft.py
@@ -22,9 +22,9 @@ class DraftNameHandler(BaseHandler):
 
         cursor.execute('SELECT name FROM drafts WHERE name=%s', (name, ))
         for result in cursor:
-            return self.make_response('Name exists')
+            return self.make_response(DraftConfig.NAME_TAKEN_RESPONSE)
 
-        return self.make_response('No draft exists with that name', status=404)
+        return self.make_response(DraftConfig.NAME_AVAILABLE_RESPONSE)
 
 
 class DraftTeamHandler(BaseHandler):

--- a/Web/utils/base_handler.py
+++ b/Web/utils/base_handler.py
@@ -15,3 +15,6 @@ class BaseHandler(object):
 
     def abort(self, code):
         flask.abort(code)
+
+    def make_response(self, response, status=200, headers={}):
+        return flask.make_response(response, status, headers)

--- a/Web/utils/wrappers.py
+++ b/Web/utils/wrappers.py
@@ -1,0 +1,64 @@
+import json
+
+import MySQLdb
+
+from config import DBConfig
+
+
+def db_cursor(db):
+    def func_wrapper(func):
+        def wrapper(*args, **kwargs):
+            connection = MySQLdb.connect(
+                host=DBConfig.HOST,
+                user=DBConfig.USER,
+                passwd=DBConfig.PASSWORD,
+                db=db
+            )
+            cursor = connection.cursor()
+            ret_val = func(cursor, *args, **kwargs)
+            cursor.close()
+            connection.close()
+            return ret_val
+        return wrapper
+    return func_wrapper
+
+
+def db_conn(db):
+    def func_wrapper(func):
+        def wrapper(*args, **kwargs):
+            connection = MySQLdb.connect(
+                host=DBConfig.HOST,
+                user=DBConfig.USER,
+                passwd=DBConfig.PASSWORD,
+                db=db
+            )
+            ret_val = func(connection, *args, **kwargs)
+            connection.close()
+            return ret_val
+        return wrapper
+    return func_wrapper
+
+
+def require_params(*params):
+    def func_wrapper(func):
+        def wrapper(*args, **kwargs):
+            self = args[0]
+
+            # Parse request data as JSON
+            request_json = None
+            try:
+                request_json = json.loads(self.request.data)
+            except ValueError as e:
+                self.abort(400)
+
+            # Get value of each required param
+            param_vals = []
+            for param in params:
+                if param not in request_json:
+                    return self.make_response('Required "{}" but did not find it'.format(param), 400)
+                param_vals.append(request_json[param])
+
+            # Call func with required params
+            return func(*(param_vals + list(args)), **kwargs)
+        return wrapper
+    return func_wrapper

--- a/config.py
+++ b/config.py
@@ -15,3 +15,5 @@ class DBConfig:
 
 class DraftConfig:
     MAX_TEAM_NAME_LENGTH = 255
+    NAME_AVAILABLE_RESPONSE = 'available'
+    NAME_TAKEN_RESPONSE = 'taken'

--- a/config.py
+++ b/config.py
@@ -12,3 +12,6 @@ class DBConfig:
     TEAMS_TABLE = 'teams'
     PLAYERS_TABLE = 'players'
     GOALIES_TABLE = 'goalies'
+
+class DraftConfig:
+    MAX_TEAM_NAME_LENGTH = 255


### PR DESCRIPTION
Made the `/draft/name` endpoint return:
- 404 if no draft exists with the provided name
- 415 on invalid name
- 200 on draft already exists

Made some function wrappers for:
- Getting DB cursors
- Getting DB connections
- Requiring parameters in a request payload