### PR TITLE
Show retry popup on load failure

### DIFF
--- a/Javascript/draft.js
+++ b/Javascript/draft.js
@@ -19,6 +19,18 @@ window.addEventListener('load', function() {
 
     /* Create notification manager */
     var notification_manager = new Notify.NotificationManager();
+    draft.addEventListener(Draft.LOAD_FAILURE_EVENT, () => {
+        notification_manager.popup(
+            'Failed to load draft options',
+            'There was a problem downloading the available players and teams from our servers. ' +
+            'Please make sure you are connected to a reliable network! ' +
+            'If the problem persists, we may have screwed up.',
+            () => {
+                draft.get_options_async();
+            },
+            'retry'
+        );
+    })
 
     /* Create screens for each step of the draft */
     var screen_mgr = new ViewUtils.ScreenManager(notification_manager);

--- a/Javascript/screen/draft.js
+++ b/Javascript/screen/draft.js
@@ -1,5 +1,5 @@
 const Screen = require('./screen');
-const Title = require('../widget/title');
+const Text = require('../widget/text');
 const Dialogue = require('../widget/dialogue');
 const Request = require('../utils/request');
 
@@ -9,7 +9,7 @@ const DRAFT_NAME_AVAILABLE_URL = 'http://localhost:5000/draft/name'
 class TitleScreen extends Screen.Screen {
     constructor(title) {
         super();
-        this.title = new Title.Title(title);
+        this.title = new Text.Title(title);
         var title_elem = this.title.get_element();
         title_elem.style.position = 'relative';
         title_elem.style.top = '50%';
@@ -29,7 +29,7 @@ class TitleScreen extends Screen.Screen {
 class NameScreen extends Screen.Screen {
     constructor(draft_model) {
         super();
-        this.dialogue = new Dialogue.TextDialogue('Select a name for the draft', 'Draft Name', this.validator);
+        this.dialogue = new Dialogue.TextDialogue('Select a name for the draft', 'Draft name', this.validator);
         var dialogue_elem = this.dialogue.get_element();
         dialogue_elem.style.position = 'relative';
         dialogue_elem.style.top = '50%';

--- a/Javascript/utils/notify.js
+++ b/Javascript/utils/notify.js
@@ -1,5 +1,6 @@
 const ViewUtils = require('./view_utils');
 const Animate = require('./animate');
+const Popup = require('../widget/popup');
 
 const TIMEOUT = 5000;
 const ANIMATION_DURATION = 300;
@@ -11,6 +12,15 @@ class NotificationManager extends ViewUtils.ViewObject {
         this.element = document.createElement('div');
         this.element.setAttribute('class', 'notification-manager-widget');
         this.notifications = [];
+    }
+
+    popup(title, message, callback, type) {
+        var popup = new Popup.Popups[type](title, message);
+        popup.addEventListener(Popup.ACTION_EVENT, (action) => {
+            this.element.removeChild(popup.get_element());
+            callback(action);
+        });
+        this.element.appendChild(popup.get_element());
     }
 
     notify(message) {

--- a/Javascript/widget/dialogue.js
+++ b/Javascript/widget/dialogue.js
@@ -1,5 +1,5 @@
 const ViewUtils = require('../utils/view_utils');
-const Title = require('./title');
+const Text = require('./text');
 const Button = require('./button');
 
 const SUBMIT_EVENT = 'submit';
@@ -12,7 +12,7 @@ class TextDialogue extends ViewUtils.ViewObject {
         this.validator = validator;
         this.element = document.createElement('div');
         this.element.setAttribute('class', 'dialogue-widget');
-        var title_widget = new Title.Title(title);
+        var title_widget = new Text.Title(title);
         var title_widget_elem = title_widget.get_element();
         title_widget.get_element().style.fontSize = '2em';
 
@@ -107,7 +107,7 @@ class NumberDialogue extends ViewUtils.ViewObject {
         super();
         this.element = document.createElement('div');
         this.element.setAttribute('class', 'dialogue-widget');
-        var title_widget = new Title.Title(title);
+        var title_widget = new Text.Title(title);
         title_widget.get_element().style.fontSize = '2em';
 
         this.picker = document.createElement('input');

--- a/Javascript/widget/popup.js
+++ b/Javascript/widget/popup.js
@@ -1,0 +1,61 @@
+const ViewUtils = require('../utils/view_utils');
+
+const Text = require('./text');
+const Button = require('./button');
+
+const ACTION_EVENT = 'action';
+const RETRY_ACTION = 'retry';
+
+
+class Popup extends ViewUtils.ViewObject {
+    constructor(title, message) {
+        super();
+        this.element = document.createElement('div');
+        this.element.setAttribute('class', 'popup-widget-background');
+        this.popup = document.createElement('div');
+        this.popup.setAttribute('class', 'popup-widget');
+        var title_widget = new Text.Title(title);
+        var title_elem = title_widget.get_element();
+        title_elem.style.fontSize = '1.8em';
+        var paragraph_widget = new Text.Paragraph(message);
+        var paragraph_elem = paragraph_widget.get_element();
+        paragraph_elem.style.fontSize = '1.3em';
+        paragraph_elem.style.marginTop = '10px';
+
+        this.popup.appendChild(title_elem);
+        this.popup.appendChild(paragraph_elem);
+        this.element.appendChild(this.popup);
+    }
+}
+
+
+class RetryPopup extends Popup {
+    constructor(title, message) {
+        super(title, message);
+
+        var button_container = document.createElement('div');
+        button_container.style.width = '100%';
+        button_container.style.textAlign = 'center';
+        button_container.style.marginTop = '10px';
+        button_container.style.fontSize = '1.3em';
+        
+        var retry = new Button.BoxButton('Retry');
+        retry.addEventListener('click', () => {
+            this._emit(ACTION_EVENT, [RETRY_ACTION]);
+        });
+
+        button_container.appendChild(retry.get_element());
+        this.popup.appendChild(button_container);
+    }
+}
+
+
+const Popups = {
+    'retry': RetryPopup
+};
+
+
+exports.Popups = Popups;
+exports.RetryPopup = RetryPopup;
+exports.RETRY_ACTION = RETRY_ACTION;
+exports.ACTION_EVENT = ACTION_EVENT;

--- a/Javascript/widget/text.js
+++ b/Javascript/widget/text.js
@@ -11,4 +11,15 @@ class Title extends ViewUtils.ViewObject {
 }
 
 
+class Paragraph extends ViewUtils.ViewObject {
+    constructor(paragraph_text) {
+        super();
+        this.element = document.createElement('div');
+        this.element.setAttribute('class', 'paragraph-widget');
+        this.element.innerText = paragraph_text;
+    }
+}
+
+
 exports.Title = Title;
+exports.Paragraph = Paragraph;

--- a/Web/static/css/draft.css
+++ b/Web/static/css/draft.css
@@ -15,6 +15,15 @@ body {
     height: 100%;
 }
 
+.popup-widget-background {
+    width: 100%;
+    height: 100%;
+    background-color: rgba(0, 0, 0, 0.6);
+    position: fixed;
+    left: 0;
+    top: 0;
+}
+
 .screen {
     position: fixed;
     top: 0;
@@ -27,10 +36,23 @@ body {
     text-align: center;
 }
 
-.dialogue-widget {
+.paragraph-widget {
+    width: 100%;
+    text-align: left;
+}
+
+.popup-widget, .dialogue-widget {
     max-width: 500px;
     border: 3px solid;
     padding: 20px;
+}
+
+.popup-widget {
+    left: 50%;
+    top: 50%;
+    transform: translate(-50%, -50%);
+    position: relative;
+    background-color: black;
 }
 
 .button-widget {


### PR DESCRIPTION
Show a popup when our request to download the players in the draft fails.
- Added a `popup` method to the notification manager
- Listen for the draft model's `LOAD_FAILURE_EVENT` to create the retry popup

![draft_load_error](https://cloud.githubusercontent.com/assets/6856391/20862364/5d842ff4-b976-11e6-960a-9cf670d172b5.png)
